### PR TITLE
Adds a note about setting up the ShipEngine Connect local API first

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ ShipEngine Connect Local Dev UI
 
 This package provides a web interface for interacting with [ShipEngine Connect](https://connect.shipengine.com) apps on a local dev machine.
 
+*Note: You need to have the ShipEngine Connect [local API](https://github.com/ShipEngine/connect-local-dev-api) up and running.*
+
 
 Development
 ---------------------


### PR DESCRIPTION
Adds note and link that this repo requires setting up the `connect-local-dev-api` to work. It might be obvious but I think it could help to be explicit.