### PR TITLE
Add language to submit form

### DIFF
--- a/src/screens/connect-method-screen/connect-form.tsx
+++ b/src/screens/connect-method-screen/connect-form.tsx
@@ -31,6 +31,7 @@ const ConnectFrom: FunctionComponent<Props> = ({ connectSchema, connectUiSchema,
     const body = {
       transaction: {
         id: uuidv4(),
+        language: '*',
         session: {},
       },
       connectionFormData: formSubmit.formData,


### PR DESCRIPTION
People were getting errors when using the connect form, because this field was recently added as required to the request.